### PR TITLE
fix: wire blog to Sanity + SSR adapter + blog index page

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -3,9 +3,17 @@ import mdx from '@astrojs/mdx';
 import sitemap from '@astrojs/sitemap';
 import tailwind from '@astrojs/tailwind';
 import sanity from '@sanity/astro';
+import vercel from '@astrojs/vercel/serverless';
 
 export default defineConfig({
-  site: 'https://axis.thelastlineofcode.com', // update to final domain
+  site: 'https://axis.thelastlineofcode.com',
+  output: 'hybrid',
+  adapter: vercel({
+    isr: {
+      // Cache blog pages for 5 minutes, revalidate in background
+      expiration: 300,
+    },
+  }),
   integrations: [
     mdx(),
     sitemap(),
@@ -13,8 +21,7 @@ export default defineConfig({
     sanity({
       projectId: process.env.SANITY_PROJECT_ID,
       dataset: process.env.SANITY_DATASET ?? 'production',
-      useCdn: true,
-      // studioBasePath: '/studio', // uncomment to embed studio
+      useCdn: false, // false for SSR so we always get fresh content
     }),
   ],
 });

--- a/package.json
+++ b/package.json
@@ -11,9 +11,9 @@
   },
   "dependencies": {
     "@astrojs/mdx": "^3.0.0",
-    "@astrojs/sanity": "^1.0.0",
     "@astrojs/sitemap": "^3.0.0",
     "@astrojs/tailwind": "^5.0.0",
+    "@astrojs/vercel": "^7.0.0",
     "@sanity/astro": "^1.0.0",
     "@sanity/client": "^6.0.0",
     "@sanity/image-url": "^1.0.0",

--- a/src/pages/blog/[slug].astro
+++ b/src/pages/blog/[slug].astro
@@ -1,21 +1,109 @@
 ---
 import BaseLayout from '../../layouts/BaseLayout.astro';
+import { useSanityClient } from '@sanity/astro';
 
-export async function getStaticPaths() {
-  // TODO: Replace with Sanity GROQ fetch once configured
-  // const client = useSanityClient();
-  // const posts = await client.fetch(`*[_type == "post"]{ slug }`);
-  // return posts.map((p: any) => ({ params: { slug: p.slug.current } }));
-  return [];
-}
+export const prerender = false; // SSR — fetch fresh from Sanity on each request
 
 const { slug } = Astro.params;
-// TODO: Fetch post by slug from Sanity
+
+const client = useSanityClient();
+
+const post = await client.fetch(
+  `*[_type == "post" && slug.current == $slug][0]{
+    title,
+    description,
+    publishedAt,
+    updatedAt,
+    planet,
+    nakshatra,
+    pillar,
+    isPaid,
+    tags,
+    degree,
+    ayanamsa,
+    subLord,
+    dasha,
+    body
+  }`,
+  { slug }
+);
+
+if (!post) {
+  return Astro.redirect('/blog', 302);
+}
+
+const pillarLabel: Record<string, string> = {
+  MUNDANE_MYSTIC: 'Mundane Mystic',
+  THE_AXIS: 'The Axis',
+  TIMING_REPORT: 'Timing Report',
+};
 ---
 
-<BaseLayout title="Post" description="">
+<BaseLayout title={post.title} description={post.description ?? ''}>
   <article class="max-w-3xl mx-auto px-6 py-20">
-    <p class="text-axis-gold font-mono text-sm">Post: {slug}</p>
-    <p class="text-gray-500 mt-4">Content loading once Sanity is wired.</p>
+
+    <!-- Header -->
+    <header class="mb-12">
+      <div class="flex gap-3 items-center mb-4">
+        <span class="font-mono text-xs text-axis-gold tracking-widest uppercase">
+          {pillarLabel[post.pillar] ?? post.pillar}
+        </span>
+        {post.isPaid && (
+          <span class="font-mono text-xs bg-axis-gold/20 text-axis-gold px-2 py-0.5 rounded">Members</span>
+        )}
+      </div>
+
+      <h1 class="font-serif text-4xl md:text-5xl text-white mb-4 leading-tight">{post.title}</h1>
+
+      {post.description && (
+        <p class="text-gray-400 text-lg mb-6 leading-relaxed">{post.description}</p>
+      )}
+
+      <!-- Astrological metadata bar -->
+      <div class="flex flex-wrap gap-4 text-xs font-mono text-gray-600 border-t border-axis-indigo-mid/40 pt-4">
+        <time datetime={post.publishedAt}>
+          {new Date(post.publishedAt).toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' })}
+        </time>
+        {post.planet && <span>· {post.planet}</span>}
+        {post.nakshatra && <span>· {post.nakshatra}</span>}
+        {post.degree && <span>· {post.degree}</span>}
+        {post.dasha && <span>· Dasha: {post.dasha}</span>}
+        {post.subLord && <span>· Sub-Lord: {post.subLord}</span>}
+        <span>· Ayanamsa: {post.ayanamsa ?? 'Lahiri'}</span>
+      </div>
+
+      {post.tags && post.tags.length > 0 && (
+        <div class="flex flex-wrap gap-2 mt-4">
+          {post.tags.map((tag: string) => (
+            <span class="font-mono text-xs bg-axis-indigo-mid/30 text-gray-400 px-2 py-0.5 rounded">{tag}</span>
+          ))}
+        </div>
+      )}
+    </header>
+
+    <!-- Body -->
+    <div class="prose prose-invert prose-gold max-w-none">
+      {post.body ? (
+        // Render raw text blocks from Sanity PortableText
+        // TODO: swap for @portabletext/astro once installed
+        post.body
+          .filter((block: any) => block._type === 'block')
+          .map((block: any) => (
+            <p class="text-gray-300 leading-relaxed mb-4">
+              {block.children?.map((span: any) => span.text).join('')}
+            </p>
+          ))
+      ) : (
+        <p class="text-gray-600 font-mono text-sm">Content coming soon.</p>
+      )}
+    </div>
+
+    <!-- Footer nav -->
+    <footer class="mt-20 pt-8 border-t border-axis-indigo-mid/40">
+      <a href="/blog" class="font-mono text-xs text-axis-gold tracking-widest uppercase hover:text-white transition-colors">
+        ← Back to all dispatches
+      </a>
+    </footer>
+
   </article>
 </BaseLayout>

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -1,0 +1,85 @@
+---
+import BaseLayout from '../../layouts/BaseLayout.astro';
+import PostCard from '../../components/PostCard.astro';
+import { useSanityClient } from '@sanity/astro';
+
+export const prerender = false; // SSR — always fresh
+
+const client = useSanityClient();
+
+const posts = await client.fetch(
+  `*[_type == "post" && draft != true] | order(publishedAt desc){
+    title,
+    "slug": slug.current,
+    description,
+    publishedAt,
+    planet,
+    nakshatra,
+    pillar,
+    isPaid,
+    tags
+  }`
+);
+
+// Pillar filter from query param (e.g. /blog?pillar=MUNDANE_MYSTIC)
+const activePillar = Astro.url.searchParams.get('pillar') ?? 'ALL';
+
+const filtered = activePillar === 'ALL'
+  ? posts
+  : posts.filter((p: any) => p.pillar === activePillar);
+
+const pillars = [
+  { key: 'ALL', label: 'All Dispatches' },
+  { key: 'MUNDANE_MYSTIC', label: 'Mundane Mystic' },
+  { key: 'THE_AXIS', label: 'The Axis' },
+  { key: 'TIMING_REPORT', label: 'Timing Report' },
+];
+---
+
+<BaseLayout
+  title="Dispatches — AXIS"
+  description="Sacred intelligence dispatches. Sidereal astrology, KP nakshatras, African ancestral cosmology, and live geopolitical cross-reference."
+>
+  <section class="max-w-4xl mx-auto px-6 py-20">
+
+    <!-- Page header -->
+    <div class="mb-12">
+      <p class="font-mono text-xs text-axis-gold tracking-widest uppercase mb-3">Sacred Intelligence</p>
+      <h1 class="font-serif text-4xl md:text-5xl text-white mb-4">Dispatches</h1>
+      <p class="text-gray-500 max-w-xl">
+        Real planetary positions. Real world events. No sun-sign noise.
+      </p>
+    </div>
+
+    <!-- Pillar filter tabs -->
+    <nav class="flex flex-wrap gap-2 mb-12">
+      {pillars.map(({ key, label }) => (
+        <a
+          href={key === 'ALL' ? '/blog' : `/blog?pillar=${key}`}
+          class={`font-mono text-xs tracking-widest uppercase px-4 py-2 rounded border transition-colors ${
+            activePillar === key
+              ? 'border-axis-gold text-axis-gold bg-axis-gold/10'
+              : 'border-axis-indigo-mid/40 text-gray-500 hover:border-axis-gold/40 hover:text-gray-300'
+          }`}
+        >
+          {label}
+        </a>
+      ))}
+    </nav>
+
+    <!-- Post grid -->
+    {filtered.length === 0 ? (
+      <div class="border border-axis-indigo-mid/40 rounded-lg p-12 text-center">
+        <p class="text-gray-600 font-mono text-sm">No dispatches yet. First transmission incoming.</p>
+        <a href="/" class="mt-4 inline-block font-mono text-xs text-axis-gold tracking-widest uppercase hover:text-white transition-colors">
+          Subscribe to be notified →
+        </a>
+      </div>
+    ) : (
+      <div class="grid gap-6">
+        {filtered.map((post: any) => <PostCard post={post} />)}
+      </div>
+    )}
+
+  </section>
+</BaseLayout>


### PR DESCRIPTION
## What this fixes

The blog was structurally scaffolded but not functional. Three blockers prevented a working Vercel deploy:

### 1. Duplicate Sanity package removed
`@astrojs/sanity` was listed alongside `@sanity/astro` — the former doesn't exist as a real integration. Removed it. Only `@sanity/astro` remains.

### 2. Vercel SSR adapter added (`hybrid` mode)
- Added `@astrojs/vercel` to deps
- `astro.config.mjs` now uses `output: 'hybrid'` + `adapter: vercel({ isr: { expiration: 300 } })`
- **Hybrid mode** means static pages stay static (fast), while blog pages are SSR with 5-minute ISR cache
- New Sanity posts go live without a full redeploy

### 3. `[slug].astro` — wired to live Sanity GROQ
- `export const prerender = false` — SSR per request
- Fetches full post by slug including all astrological metadata fields
- Renders astrological metadata bar (planet, nakshatra, degree, dasha, sub-lord, ayanamsa)
- Renders `body` PortableText blocks as `<p>` tags (raw fallback — swap for `@portabletext/astro` for full rich text later)
- 404s redirect to `/blog`

### 4. `src/pages/blog/index.astro` — new listing page
- SSR, always fresh from Sanity
- Filters out drafts
- Pillar filter tabs: All / Mundane Mystic / The Axis / Timing Report
- Query-param driven (`/blog?pillar=MUNDANE_MYSTIC`)
- Empty state with subscribe CTA

---

## Before merging — required Vercel env vars

Set these in your Vercel project settings → Environment Variables:

| Variable | Value |
|---|---|
| `SANITY_PROJECT_ID` | Your Sanity project ID (from sanity.io/manage) |
| `SANITY_DATASET` | `production` |

---

## TODO (follow-up)
- [ ] Install `@portabletext/astro` for full rich-text rendering
- [ ] Add OG image generation per post
- [ ] Add members-only gate on `isPaid` posts
